### PR TITLE
Allow free products to be upgraded without licenses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
 import:
  - gocodebox/lifterlms:.config/travis/add-on.yml
+
+jobs:
+  include:
+  - php: "8.0"
+    env: WP_VERSION=latest LLMS_COM_API_INTEGRATION_TESTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,11 @@ import:
 
 jobs:
   include:
+  # Run API Integration tests on latest WP & PHP Versions.
   - php: "8.0"
     env: WP_VERSION=latest LLMS_COM_API_INTEGRATION_TESTS=1
+
+  exclude:
+  # Excluded because the integration test above covers this build.
+  - php: "8.0"
+    env: WP_VERSION=latest

--- a/includes/class-llms-helper-admin-add-ons.php
+++ b/includes/class-llms-helper-admin-add-ons.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Helper/Classes
  *
  * @since 3.0.0
- * @version 3.0.2
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -303,6 +303,7 @@ class LLMS_Helper_Admin_Add_Ons {
 	 * Does not output for "featured" items on general settings.
 	 *
 	 * @since 3.0.0
+	 * @since [version] Output single install action if the addon doesn't require license (e.g. free product).
 	 *
 	 * @param obj    $addon    LLMS_Add_On instance.
 	 * @param string $curr_tab Slug of the current tab being viewed.
@@ -314,7 +315,7 @@ class LLMS_Helper_Admin_Add_Ons {
 			return;
 		}
 
-		if ( $addon->is_installable() && ! $addon->is_installed() && $addon->is_licensed() ) {
+		if ( $addon->is_installable() && ! $addon->is_installed() && ( ! $addon->requires_license() || $addon->is_licensed() ) ) {
 			?>
 			<label class="llms-status-icon status--<?php echo esc_attr( $addon->get_install_status() ); ?>" for="<?php echo esc_attr( sprintf( '%s-install', $addon->get( 'id' ) ) ); ?>">
 				<input class="llms-bulk-check" data-action="install" name="llms_install[]" id="<?php echo esc_attr( sprintf( '%s-install', $addon->get( 'id' ) ) ); ?>" type="checkbox" value="<?php echo esc_attr( $addon->get( 'id' ) ); ?>">
@@ -336,6 +337,7 @@ class LLMS_Helper_Admin_Add_Ons {
 	 * Does not output for "featured" items on general settings.
 	 *
 	 * @since 3.0.0
+	 * @since [version] Output single update action if the addon doesn't require license (e.g. free product).
 	 *
 	 * @param obj    $addon    LLMS_Add_On instance.
 	 * @param string $curr_tab Slug of the current tab being viewed.
@@ -347,7 +349,7 @@ class LLMS_Helper_Admin_Add_Ons {
 			return;
 		}
 
-		if ( $addon->is_installable() && $addon->is_installed() && $addon->is_licensed() && $addon->has_available_update() ) {
+		if ( $addon->is_installable() && $addon->is_installed() && ( ! $addon->requires_license() || $addon->is_licensed() ) && $addon->has_available_update() ) {
 			?>
 			<label class="llms-status-icon status--update-available" for="<?php echo esc_attr( sprintf( '%s-update', $addon->get( 'id' ) ) ); ?>">
 				<input class="llms-bulk-check" data-action="update" name="llms_update[]" id="<?php echo esc_attr( sprintf( '%s-update', $addon->get( 'id' ) ) ); ?>" type="checkbox" value="<?php echo esc_attr( $addon->get( 'id' ) ); ?>">

--- a/includes/class-llms-helper-admin-add-ons.php
+++ b/includes/class-llms-helper-admin-add-ons.php
@@ -133,26 +133,33 @@ class LLMS_Helper_Admin_Add_Ons {
 	 *
 	 * @since 3.0.0
 	 * @since 3.2.0 Let the LifterLMS Core output flashed notices
+	 * @since [version] Flush cached addon and package update data when adding or removing keys.
 	 *
 	 * @return void
 	 */
 	public function handle_actions() {
 
 		// License key addition & removal.
-		if ( llms_verify_nonce( '_llms_manage_keys_nonce', 'llms_manage_keys' ) ) {
+		if ( ! llms_verify_nonce( '_llms_manage_keys_nonce', 'llms_manage_keys' ) ) {
+			return;
+		}
 
-			if ( isset( $_POST['llms_activate_keys'] ) && ! empty( $_POST['llms_add_keys'] ) ) {
+		$flush = false;
 
-				$this->handle_activations();
+		if ( isset( $_POST['llms_activate_keys'] ) && ! empty( $_POST['llms_add_keys'] ) ) {
 
-			} elseif ( isset( $_POST['llms_deactivate_keys'] ) && ! empty( $_POST['llms_remove_keys'] ) ) {
+			$flush = true;
+			$this->handle_activations();
 
-				$this->handle_deactivations();
+		} elseif ( isset( $_POST['llms_deactivate_keys'] ) && ! empty( $_POST['llms_remove_keys'] ) ) {
 
-			}
+			$flush = true;
+			$this->handle_deactivations();
 
-			delete_site_transient( 'update_plugins' );
+		}
 
+		if ( $flush ) {
+			llms_helper_flush_cache();
 		}
 
 	}

--- a/includes/class-llms-helper-betas.php
+++ b/includes/class-llms-helper-betas.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Helper/Classes
  *
  * @since 3.0.0
- * @version 3.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -51,6 +51,7 @@ class LLMS_Helper_Betas {
 	 *
 	 * @since 3.0.0
 	 * @since 3.2.0 Don't access `$_POST` directly.
+	 * @since [version] Flush transient caches when a subscription changes.
 	 *
 	 * @return null|string Returns null when nonce errors or invalid data are submitted, otherwise returns an array of addon subscription data.
 	 */
@@ -65,12 +66,20 @@ class LLMS_Helper_Betas {
 			return;
 		}
 
+		$new_subscription = false;
+
 		foreach ( $subs as $id => $channel ) {
 
 			$addon = llms_get_add_on( $id );
 			if ( 'channel' !== $addon->get_channel_subscription() ) {
 				$addon->subscribe_to_channel( sanitize_text_field( $channel ) );
+				$new_subscription = true;
 			}
+		}
+
+		// When a channel subscription changes also flush caches so we'll get the most recent add-on data immediately and allow upgrading immediately from wp core update screens.
+		if ( $new_subscription ) {
+			llms_helper_flush_cache();
 		}
 
 		return $subs;

--- a/includes/class-llms-helper-upgrader.php
+++ b/includes/class-llms-helper-upgrader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Helper/Classes
  *
  * @since 3.0.0
- * @version 3.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,7 +16,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0.0
  * @since 3.0.2 Unknown.
  * @since 3.1.0 Load changelogs from the make blog in favor of static html changelogs.
- * @since version] Use `$instance` in favor of `$_instance`.
  */
 class LLMS_Helper_Upgrader {
 
@@ -469,6 +468,7 @@ class LLMS_Helper_Upgrader {
 	 *
 	 * @since 3.0.0
 	 * @since 3.0.2 Unknown.
+	 * @since [version] Correctly process addons which do not require a license (e.g. free products).
 	 *
 	 * @param array $options Package option data.
 	 * @return array
@@ -488,7 +488,7 @@ class LLMS_Helper_Upgrader {
 		}
 
 		$addon = llms_get_add_on( $file, 'update_file' );
-		if ( ! $addon || ! $addon->is_installable() || ! $addon->is_licensed() ) {
+		if ( ! $addon || ! $addon->is_installable() || ( $addon->requires_license() && ! $addon->is_licensed() ) ) {
 			return $options;
 		}
 

--- a/includes/functions-llms-helper.php
+++ b/includes/functions-llms-helper.php
@@ -44,3 +44,18 @@ function llms_helper_get_available_add_ons( $installable_only = true ) {
 	return array_unique( $ids );
 
 }
+
+/**
+ * Deletes transient data related to plugin and theme updates
+ *
+ * @since [version]
+ *
+ * @return void
+ */
+function llms_helper_flush_cache() {
+
+	delete_transient( 'llms_products_api_result' );
+	delete_site_transient( 'update_plugins' );
+	delete_site_transient( 'update_themes' );
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -33,6 +33,23 @@ class LLMS_Helper_Tests_Bootstrap extends LLMS_Tests_Bootstrap {
 	 */
 	public $plugin_main = 'lifterlms-helper.php';
 
+	/**
+	 * Runs immediately after $this->install()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function install_after() {
+
+		parent::install_after();
+
+		update_option( 'siteurl', 'http://llms-helper-testing.test' );
+
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/llms.functions.admin.php';
+
+	}
+
 }
 
 return new LLMS_Helper_Tests_Bootstrap();

--- a/tests/phpunit/framework/unit-test-case.php
+++ b/tests/phpunit/framework/unit-test-case.php
@@ -26,10 +26,24 @@ class LLMS_Helper_Unit_Test_Case extends LLMS_Unit_Test_Case {
 	 * Retrieve license keys to use for testing from environment vars.
 	 *
 	 * @since 3.2.0
+	 * @since [version] Only run api integration tests when explicitly specified through environment vars.
 	 *
 	 * @return void
 	 */
 	public function get_test_keys() {
+
+		/**
+		 * Skip test unless API integration tests are explicitly specified.
+		 *
+		 * This is used by Travis to only run API integrations tests on a single build
+		 * to prevent unnecessary load on the API server.
+		 *
+		 * We'll run the API tests when running code coverage too so that we get "credit"
+		 * for the integration tests.
+		 */
+		if ( ! getenv( 'LLMS_COM_API_INTEGRATION_TESTS' ) && ! getenv( 'RUN_CODE_COVERAGE' ) ) {
+			$this->markTestSkipped( 'Integration tests skipped in this environment.' );
+		}
 
 		$keys = array();
 

--- a/tests/phpunit/framework/unit-test-case.php
+++ b/tests/phpunit/framework/unit-test-case.php
@@ -5,9 +5,22 @@
  * @package LifterLMS_Helper/Tests
  *
  * @since 3.2.0
- * @version 3.2.0
  */
 class LLMS_Helper_Unit_Test_Case extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Teardown the test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+
+		parent::tearDown();
+		delete_option( 'llms_helper_options' );
+
+	}
 
 	/**
 	 * Retrieve license keys to use for testing from environment vars.
@@ -37,6 +50,34 @@ class LLMS_Helper_Unit_Test_Case extends LLMS_Unit_Test_Case {
 
 		return $keys;
 
+	}
+
+	/**
+	 * Retrieve a single test key by its test ID
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key Test key ID. See `get_test_keys()` for available key ids.
+	 * @return strinng|boolaen The license key or `false`.
+	 */
+	public function get_test_key( $key ) {
+		$keys = $this->get_test_keys();
+		return isset( $keys[ $key ] ) ? $keys[ $key ] : false;
+	}
+
+	/**
+	 * Activate a test key using the test key id
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key Test key ID. See `get_test_keys()` for available key ids.
+	 * @return array
+	 */
+	public function activate_key( $key ) {
+		$key = $this->get_test_key( $key );
+		$api = LLMS_Helper_Keys::activate_keys( $key );
+		LLMS_Helper_Keys::add_license_key( $api['data']['activations'][0] );
+		return llms_helper_options()->get_license_keys()[ $key ];
 	}
 
 }

--- a/tests/phpunit/unit-tests/add-on-model.php
+++ b/tests/phpunit/unit-tests/add-on-model.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Test LLMS_Helper_Keys class
+ *
+ * @package LifterLMS_Helper/Tests
+ *
+ * @group add_on
+ *
+ * @since [version]
+ */
+class LLMS_Helper_Test_Add_On extends LLMS_Helper_Unit_Test_Case {
+
+	/**
+	 * Test get_channel_subscripiton() and subscribe_to_channel()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_channel_subscription() {
+
+		$addon = llms_get_add_on( 'lifterlms-com-lifterlms' );
+
+		// Stable by default.
+		$this->assertEquals( 'stable', $addon->get_channel_subscription() );
+
+		// Explicitly stable.
+		$this->assertTrue( $addon->subscribe_to_channel( 'stable' ) );
+		$this->assertEquals( 'stable', $addon->get_channel_subscription() );
+
+		// Beta.
+		$this->assertTrue( $addon->subscribe_to_channel( 'beta' ) );
+		$this->assertEquals( 'beta', $addon->get_channel_subscription() );
+
+	}
+
+	/**
+	 * Test find_license() and is_licensed() for add-ons that do not require a license.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_find_license_and_is_licensed_not_required() {
+
+		$addon = llms_get_add_on( 'lifterlms-com-lifterlms' );
+
+		// No license.
+		$this->assertFalse( $addon->find_license() );
+		$this->assertFalse( $addon->is_licensed() );
+
+		$mock_keys = array(
+			'mock-key' => array(
+				'product_id' => 'does-not-matter',
+			),
+		);
+
+		// Mock saved keys.
+		llms_helper_options()->set_license_keys( $mock_keys );
+
+		// Returns the first stored key.
+		$this->assertEquals( $mock_keys['mock-key'], $addon->find_license() );
+		$this->assertTrue( $addon->is_licensed() );
+
+	}
+
+	/**
+	 * Test find_license() and is_licensed() for add-ons that require a license
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_find_license_and_is_licensed_is_required() {
+
+		$addon = llms_get_add_on( 'lifterlms-com-stripe-extension' );
+
+		// No license.
+		$this->assertFalse( $addon->find_license() );
+		$this->assertFalse( $addon->is_licensed() );
+
+		// No match.
+		$mock_keys = array(
+			'mock-key' => array(
+				'product_id' => 'no-match',
+				'addons'     => array(),
+			),
+		);
+		llms_helper_options()->set_license_keys( $mock_keys );
+		$this->assertFalse( $addon->find_license() );
+		$this->assertFalse( $addon->is_licensed() );
+
+		// Returns the key by product id.
+		$mock_keys['good-key'] = array(
+			'product_id' => 'lifterlms-com-stripe-extension',
+			'addons'     => array(),
+		);
+		llms_helper_options()->set_license_keys( $mock_keys );
+		$this->assertEquals( $mock_keys['good-key'], $addon->find_license() );
+		$this->assertTrue( $addon->is_licensed() );
+
+		// Returns the key by because it's included in the bundle.
+		$mock_keys['good-key'] = array(
+			'product_id' => 'bundle-product',
+			'addons'     => array(
+				'lifterlms-com-stripe-extension',
+			),
+		);
+		llms_helper_options()->set_license_keys( $mock_keys );
+		$this->assertEquals( $mock_keys['good-key'], $addon->find_license() );
+		$this->assertTrue( $addon->is_licensed() );
+
+	}
+
+	/**
+	 * Test get_download_info() error for no license found
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_download_info_err_no_license() {
+
+		$addon = llms_get_add_on( 'lifterlms-com-stripe-extension' );
+		$res   = $addon->get_download_info();
+
+		$this->assertIsWpError( $res );
+		$this->assertWpErrorCodeEquals( 'no_license', $res );
+
+	}
+
+	/**
+	 * Test get_download_info() license errors
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_download_info_err_with_license() {
+
+		// License & Update key are empty.
+		$mock_keys['bad-key'] = array(
+			'product_id'  => 'lifterlms-com-stripe-extension',
+			'license_key' => '',
+			'update_key'  => '',
+		);
+		llms_helper_options()->set_license_keys( $mock_keys );
+
+		$addon = llms_get_add_on( 'lifterlms-com-stripe-extension' );
+		$res   = $addon->get_download_info();
+
+		$this->assertIsWpError( $res );
+		$this->assertWpErrorCodeEquals( 'error', $res );
+		$this->assertWpErrorMessageEquals( 'Invalid credentials provided.', $res );
+
+		// Valid key but fake update key.
+		$mock_keys['bad-key'] = array(
+			'product_id'  => 'lifterlms-com-stripe-extension',
+			'license_key' => $this->get_test_key( 'STRIPE' ),
+			'update_key'  => 'fake',
+		);
+		llms_helper_options()->set_license_keys( $mock_keys );
+
+		$addon = llms_get_add_on( 'lifterlms-com-stripe-extension' );
+		$res   = $addon->get_download_info();
+
+		$this->assertIsWpError( $res );
+		$this->assertWpErrorCodeEquals( 'error', $res );
+		$this->assertWpErrorMessageEquals( 'Invalid credentials provided.', $res );
+
+	}
+
+	/**
+	 * Test get_download_info() success for an add-on that requires a license
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_download_info_success_license_required_single() {
+
+		$key = $this->activate_key( 'STRIPE' );
+
+		$addon = llms_get_add_on( 'lifterlms-com-stripe-extension' );
+		$res   = $addon->get_download_info();
+
+		$this->assertNotEmpty( $res['data']['url'] );
+		$this->assertNotEmpty( $res['data']['file'] );
+		$this->assertEquals( $addon->get( 'version' ), $res['data']['version'] );
+
+	}
+
+	/**
+	 * Test get_download_info() success for an add-on that requires a license with a bundle key
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_download_info_success_license_required_bundle() {
+
+		$key = $this->activate_key( 'UNIVERSE' );
+
+		$addon = llms_get_add_on( 'lifterlms-com-stripe-extension' );
+		$res   = $addon->get_download_info();
+
+		$this->assertNotEmpty( $res['data']['url'] );
+		$this->assertNotEmpty( $res['data']['file'] );
+		$this->assertEquals( $addon->get( 'version' ), $res['data']['version'] );
+
+	}
+
+	/**
+	 * Test get_download_info() success for an add-on that does not require a license
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_download_info_success_license_optional() {
+
+		$addon = llms_get_add_on( 'lifterlms-com-lifterlms' );
+
+		// Without keys.
+		$res = $addon->get_download_info();
+
+		$this->assertNotEmpty( $res['data']['url'] );
+		$this->assertNotEmpty( $res['data']['file'] );
+		$this->assertEquals( $addon->get( 'version' ), $res['data']['version'] );
+
+		// With keys.
+		$key = $this->activate_key( 'STRIPE' );
+		$res = $addon->get_download_info();
+
+		$this->assertNotEmpty( $res['data']['url'] );
+		$this->assertNotEmpty( $res['data']['file'] );
+		$this->assertEquals( $addon->get( 'version' ), $res['data']['version'] );
+
+	}
+
+	public function test_requires_license() {
+
+		$add_on = new LLMS_Helper_Add_On( array( 'has_license' => 'yes' ) );
+		$this->assertTrue( $add_on->requires_license() );
+
+		$add_on = new LLMS_Helper_Add_On( array( 'has_license' => 'no' ) );
+		$this->assertFalse( $add_on->requires_license() );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/functions.php
+++ b/tests/phpunit/unit-tests/functions.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Test helper functions
+ *
+ * @package LifterLMS_Helper/Tests
+ *
+ * @group functions
+ *
+ * @since [version]
+ */
+class LLMS_Helper_Test_Functions extends LLMS_Helper_Unit_Test_Case {
+
+	/**
+	 * Test llms_helper_options() function
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_helper_options() {
+
+		$instance = llms_helper_options();
+		$this->assertTrue( $instance instanceof LLMS_Helper_Options );
+
+	}
+
+	/**
+	 * Test llms_helper_flush_cache()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_helper_flush_cache() {
+
+		// Prime the caches.
+		set_transient( 'llms_products_api_result', 'fake-data', HOUR_IN_SECONDS );
+		set_site_transient( 'update_themes', 'fake-data', HOUR_IN_SECONDS );
+		set_site_transient( 'update_plugins', 'fake-data', HOUR_IN_SECONDS );
+
+		llms_helper_flush_cache();
+
+		$this->assertEmpty( get_transient( 'llms_products_api_result' ) );
+		$this->assertEmpty( get_site_transient( 'update_themes' ) );
+		$this->assertEmpty( get_site_transient( 'update_plugins' ) );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/keys.php
+++ b/tests/phpunit/unit-tests/keys.php
@@ -4,12 +4,105 @@
  *
  * @package LifterLMS_Helper/Tests
  *
- * @group main
+ * @group keys
  *
  * @since 3.2.0
- * @version 3.2.0
  */
 class LLMS_Helper_Test_Keys extends LLMS_Helper_Unit_Test_Case {
+
+	/**
+	 * Test activate_keys() and deactivate_keys() with real active keys
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_activate_deactivate_add_remove_keys_real_active_key() {
+
+		$key = $this->get_test_key( 'STRIPE' );
+
+		$activation_res = LLMS_Helper_Keys::activate_keys( $key );
+		$activation     = $activation_res['data']['activations'][0];
+
+		$this->assertEquals( array(), $activation_res['data']['errors'] );
+		$this->assertEquals( 'lifterlms-com-stripe-extension', $activation['id'] );
+		$this->assertEquals( $key, $activation['license_key'] );
+		$this->assertEquals( 'TEST', $activation['type'] );
+		$this->assertEquals( 1, $activation['status'] );
+		$this->assertEquals( wp_parse_url( get_site_url(), PHP_URL_HOST ), $activation['url'] );
+		$this->assertEquals( array( 'lifterlms-com-stripe-extension' ), $activation['addons'] );
+
+		$this->assertNotEmpty( $activation['update_key'] );
+
+		// Store the key so we can remove it later.
+		$this->assertTrue( LLMS_Helper_Keys::add_license_key( $activation ) );
+
+		// Make sure option is stored properly.
+		$options = llms_helper_options()->get_license_keys();
+		$expect  = array(
+			'product_id'  => $activation['id'],
+			'status'      => 1,
+			'license_key' => $key,
+			'update_key'  => $activation['update_key'],
+			'addons'      => $activation['addons'],
+		);
+		$this->assertEquals( $expect, $options[ $key ] );
+
+		// Test deactivation.
+		$deactivation_res = LLMS_Helper_Keys::deactivate_keys( array( $key ) );
+		$deactivation     = $deactivation_res['data']['deactivations'][0];
+
+		$this->assertEquals( array(), $deactivation_res['data']['errors'] );
+		$this->assertEquals( 'lifterlms-com-stripe-extension', $activation['id'] );
+		$this->assertEquals( $key, $deactivation['license_key'] );
+		$this->assertEquals( 'TEST', $deactivation['type'] );
+		$this->assertEquals( 0, $deactivation['status'] );
+		$this->assertEquals( wp_parse_url( get_site_url(), PHP_URL_HOST ), $deactivation['url'] );
+		$this->assertEquals( array(), $deactivation['addons'] );
+
+		$this->assertNotEmpty( $deactivation['update_key'] );
+
+		// Remove the key.
+		$this->assertTrue( LLMS_Helper_Keys::remove_license_key( $key ) );
+		$this->assertEquals( array(),  llms_helper_options()->get_license_keys() );
+
+	}
+
+	/**
+	 * Test activate_keys() and deactivate_keys() with real inactive keys
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_activate_keys_real_inactive_key() {
+
+		$key = $this->get_test_key( 'INACTIVE' );
+		$ret = LLMS_Helper_Keys::activate_keys( $key );
+
+		$expect = "\"{$key}\" is not an active license key. The current status is \"Cancelled\". Visit your account dashboard at https://lifterlms.com/my-account to renew the license key.";
+		$this->assertEquals( array( $expect ), $ret['data']['errors'] );
+		$this->assertEquals( array(), $ret['data']['activations'] );
+
+	}
+
+	/**
+	 * Test activate_keys() and deactivate_keys() with an invalid key
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_activate_keys_real_fake_key() {
+
+		$key = 'fake-key';
+		$ret = LLMS_Helper_Keys::activate_keys( $key );
+
+		$expect = "\"{$key}\" is not a valid license key. Please ensure your license key is correct and try again.";
+		$this->assertEquals( array( $expect ), $ret['data']['errors'] );
+		$this->assertEquals( array(), $ret['data']['activations'] );
+
+	}
 
 	/**
 	 * Test activate_keys() to sanitize and parse acceptable types of input data.


### PR DESCRIPTION
Fixes #13 
Based on #14 

Additionally flushes cached transient data when changing subscriptions on the betas screen.