### PR TITLE
Install updates

### DIFF
--- a/class-lifterlms-helper.php
+++ b/class-lifterlms-helper.php
@@ -75,7 +75,7 @@ final class LifterLMS_Helper {
 		 *
 		 * When the plugin is loaded by itself as a plugin, we must localize it independently.
 		 */
-		if ( ! defined( 'LLMS_REST_API_LIB' ) || ! LLMS_REST_API_LIB ) {
+		if ( ! defined( 'LLMS_HELPER_LIB' ) || ! LLMS_HELPER_LIB ) {
 			add_action( 'init', array( $this, 'load_textdomain' ), 0 );
 		}
 

--- a/includes/class-llms-helper-install.php
+++ b/includes/class-llms-helper-install.php
@@ -33,13 +33,23 @@ class LLMS_Helper_Install {
 	 * Checks the current LLMS version and runs installer if required
 	 *
 	 * @since 3.0.0
+	 * @since [version] Use llms_helper() in favor of deprecated LLMS_Helper().
 	 *
 	 * @return void
 	 */
 	public static function check_version() {
-		if ( ! defined( 'IFRAME_REQUEST' ) && get_option( 'llms_helper_version' ) !== LLMS_Helper()->version ) {
+
+		if ( ! defined( 'IFRAME_REQUEST' ) && get_option( 'llms_helper_version' ) !== llms_helper()->version ) {
+
 			self::install();
+
+			/**
+			 * Action run after the helper library is updated.
+			 *
+			 * @since 3.0.0
+			 */
 			do_action( 'llms_helper_updated' );
+
 		}
 	}
 
@@ -47,6 +57,7 @@ class LLMS_Helper_Install {
 	 * Core install function
 	 *
 	 * @since 3.0.0
+	 * @since [version] Skip migration when loaded as a library.
 	 *
 	 * @return void
 	 */
@@ -58,10 +69,8 @@ class LLMS_Helper_Install {
 
 		do_action( 'llms_helper_before_install' );
 
-		if ( ! get_option( 'llms_helper_version', '' ) ) {
-
+		if ( ( ! defined( 'LLMS_HELPER_LIB' ) || ! LLMS_HELPER_LIB ) && ! get_option( 'llms_helper_version', '' ) ) {
 			self::_migrate_300();
-
 		}
 
 		self::update_version();
@@ -73,13 +82,14 @@ class LLMS_Helper_Install {
 	 * Update the LifterLMS version record to the latest version
 	 *
 	 * @since 3.0.0
+	 * @since [version] Use llms_helper() in favor of deprecated LLMS_Helper().
 	 *
 	 * @param string $version version number.
 	 * @return void
 	 */
 	public static function update_version( $version = null ) {
 		delete_option( 'llms_helper_version' );
-		add_option( 'llms_helper_version', is_null( $version ) ? LLMS_Helper()->version : $version );
+		add_option( 'llms_helper_version', is_null( $version ) ? llms_helper()->version : $version );
 	}
 
 	/**

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -34,6 +34,25 @@ class LLMS_Helper_Tests_Bootstrap extends LLMS_Tests_Bootstrap {
 	public $plugin_main = 'lifterlms-helper.php';
 
 	/**
+	 * Load the plugin and the LifterLMS core.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function load() {
+
+		// Disable the helper library so this version is tested.
+		add_filter( 'llms_included_libs', function( $libs ) {
+			$libs['helper']['test'] = false;
+			return $libs;
+		} );
+
+		parent::load();
+
+	}
+
+	/**
 	 * Runs immediately after $this->install()
 	 *
 	 * @since 3.2.1

--- a/tests/phpunit/unit-tests/install.php
+++ b/tests/phpunit/unit-tests/install.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Test LLMS_Helper_Install class
+ *
+ * @package LifterLMS_Helper/Tests
+ *
+ * @group install
+ *
+ * @since [version]
+ */
+class LLMS_Helper_Test_Install extends LLMS_Helper_Unit_Test_Case {
+
+	public static function setupBeforeClass() {
+
+		parent::setupBeforeClass();
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/class.llms.admin.notices.php';
+
+	}
+
+	/**
+	 * Test check_version()
+	 *
+	 * @since [version]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_check_version() {
+
+		llms_maybe_define_constant( 'LLMS_HELPER_LIB', true );
+
+		delete_option( 'llms_helper_version' );
+
+		$action = did_action( 'llms_helper_updated' );
+
+		// Update runs.
+		LLMS_Helper_Install::check_version();
+		$this->assertEquals( ++$action, did_action( 'llms_helper_updated' ) );
+
+		// Does not run.
+		LLMS_Helper_Install::check_version();
+		$this->assertEquals( $action, did_action( 'llms_helper_updated' ) );
+
+	}
+
+	/**
+	 * Test installation when running as a lib
+	 *
+	 * @since [version]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_install_as_lib() {
+
+		llms_maybe_define_constant( 'LLMS_HELPER_LIB', true );
+
+		$action_before = did_action( 'llms_helper_before_install' );
+		$action_after = did_action( 'llms_helper_after_install' );
+
+		LLMS_Helper_Install::install();
+
+		$this->assertEquals( ++$action_before, did_action( 'llms_helper_before_install' ) );
+		$this->assertEquals( ++$action_after, did_action( 'llms_helper_after_install' ) );
+
+		$this->assertEquals( llms_helper()->version, get_option( 'llms_helper_version' ) );
+
+		$notices = LLMS_Admin_Notices::get_notices();
+		$this->assertFalse( LLMS_Admin_Notices::has_notice( 'llms-flash-notice-0' ) );
+
+	}
+
+	/**
+	 * Test installation
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_install() {
+
+		$action_before = did_action( 'llms_helper_before_install' );
+		$action_after = did_action( 'llms_helper_after_install' );
+
+		LLMS_Helper_Install::install();
+
+		$this->assertEquals( ++$action_before, did_action( 'llms_helper_before_install' ) );
+		$this->assertEquals( ++$action_after, did_action( 'llms_helper_after_install' ) );
+
+		$this->assertEquals( llms_helper()->version, get_option( 'llms_helper_version' ) );
+
+		$notices = LLMS_Admin_Notices::get_notices();
+		$this->assertTrue( LLMS_Admin_Notices::has_notice( 'llms-flash-notice-0' ) );
+
+	}
+
+	/**
+	 * Test update_version()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_version() {
+
+		// Arbitrary version passed in.
+		LLMS_Helper_Install::update_version( '1.2.3' );
+		$this->assertEquals( '1.2.3', get_option( 'llms_helper_version' ) );
+
+		// Current version.
+		LLMS_Helper_Install::update_version();
+		$this->assertEquals( llms_helper()->version, get_option( 'llms_helper_version' ) );
+
+	}
+
+}


### PR DESCRIPTION
## Description

+ Fixes #28 
+ Uses the proper constant that I missed when reviewing #26 
+ Replaces usage of `LLMS_Helper()` with `llms_helper()` in the `LLMS_Helper_Install` class

## How has this been tested?

+ New unit tests

## Screenshots <!-- if applicable -->

## Types of changes

+ Bug fix
+ This creates a scenario in which users on versions earlier that 3.0 will not have keys migrated if they delete the helper and then upgrade to LifterLMS 5.0 or later. In the end this would be a minor issue and we can instruct users to migrate their keys manually or install the helper plugin, migrate, and then delete.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

