### PR TITLE
Add a `plugin` property to the returned plugin object.

### DIFF
--- a/.changelogs/plugin-property.yml
+++ b/.changelogs/plugin-property.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+links: "#36"
+entry: Fixed an issue that caused PHP warnings in the "Plugins -> Add New" page because the `plugin` property was missing.

--- a/includes/class-llms-helper-upgrader.php
+++ b/includes/class-llms-helper-upgrader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Helper/Classes
  *
  * @since 3.0.0
- * @version 3.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -313,10 +313,12 @@ class LLMS_Helper_Upgrader {
 	}
 
 	/**
-	 * Setup an object of addon data for use when requesting plugin information normally acquired from wp.org
+	 * Setup an object of addon data for use when requesting plugin information normally acquired from wp.org.
 	 *
 	 * @since 3.0.0
 	 * @since 3.2.1 Set package to `true` for add-ons which don't require a license.
+	 * @since [version] Added a `plugin` property to the returned plugin object,
+	 *              which is required by `WP_Plugin_Install_List_Table::prepare_items()`.
 	 *
 	 * @param string $id               Addon id.
 	 * @param bool   $include_sections Whether or not to include additional sections like the description and changelog.
@@ -354,6 +356,7 @@ class LLMS_Helper_Upgrader {
 		$item = array(
 			'name'           => $addon->get( 'title' ),
 			'slug'           => $id,
+			'plugin'         => $addon->get( 'update_file' ),
 			'version'        => $addon->get_latest_version(),
 			'new_version'    => $addon->get_latest_version(),
 			'author'         => '<a href="https://lifterlms.com/">' . $addon->get( 'author' )['name'] . '</a>',


### PR DESCRIPTION
## Description
Added a `plugin` property to the returned plugin object, which is required by [`WP_Plugin_Install_List_Table::prepare_items()`](https://github.com/WordPress/wordpress-develop/blob/5.9.2/src/wp-admin/includes/class-wp-plugin-install-list-table.php#L271).

Fixes #36.

## How has this been tested?
Manually.

## Types of changes
Prevents PHP warning errors.
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

