### PR TITLE
Remove empty keys during activation.

### DIFF
--- a/.changelogs/empty-keys.yml
+++ b/.changelogs/empty-keys.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Fixed an issue where adding new license keys with an end-of-line symbol after the last key
+  would result in an invalid license key error.

--- a/includes/class-llms-helper-keys.php
+++ b/includes/class-llms-helper-keys.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Helper/Classes
  *
  * @since 3.0.0
- * @version 3.4.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,10 +18,11 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Helper_Keys {
 
 	/**
-	 * Activate LifterLMS License Keys with the remote server
+	 * Activate LifterLMS License Keys with the remote server.
 	 *
 	 * @since 3.0.0
 	 * @since 3.0.1 Unknown.
+	 * @since [version] Removed empty key lines.
 	 *
 	 * @param string|array $keys Array or a white-space separated list of API keys.
 	 * @return array
@@ -36,6 +37,7 @@ class LLMS_Helper_Keys {
 		$keys = array_map( 'sanitize_text_field', $keys );
 		$keys = array_map( 'trim', $keys );
 		$keys = array_unique( $keys );
+		$keys = array_filter( $keys ); // Remove empty keys.
 
 		$data = array(
 			'keys' => $keys,

--- a/tests/phpunit/unit-tests/keys.php
+++ b/tests/phpunit/unit-tests/keys.php
@@ -121,6 +121,8 @@ class LLMS_Helper_Test_Keys extends LLMS_Helper_Unit_Test_Case {
 	 * Test activate_keys() to sanitize and parse acceptable types of input data.
 	 *
 	 * @since 3.2.0
+	 * @since [version] Added test of empty key removal.
+	 *              Replace "\n" line endings in multiple keys test with the platform specific `PHP_EOL` constant.
 	 *
 	 * @return void
 	 */
@@ -136,10 +138,10 @@ class LLMS_Helper_Test_Keys extends LLMS_Helper_Unit_Test_Case {
 		// Array is parsed and duplicates are removed.
 		LLMS_Helper_Keys::activate_keys( array( 1, 2, 2 ) );
 
-		// String with one key per line & extra white space trimmed.
-		LLMS_Helper_Keys::activate_keys( "1 \n 2 \n1" );
+		// Test a string with one key per line, trimming of extra white space, and removal of empty keys.
+		LLMS_Helper_Keys::activate_keys( '1 ' . PHP_EOL .  ' 2 ' . PHP_EOL . '1' . PHP_EOL );
 
-		remove_filter( 'pre_http_request', $handler, 10, 3 );
+		remove_filter( 'pre_http_request', $handler, 10 );
 
 	}
 


### PR DESCRIPTION
## Description
Fixed an issue where adding new license keys with an end-of-line symbol after the last key would result in an invalid license key error.

This started out as a fix for the `LLMS_Helper_Test_Keys::test_activate_keys_sanitize_and_parse()` test on Windows and evolved.

## How has this been tested?
Manually and with unit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

