### PR TITLE
Fixing incorrect html code for single Add Ons displayed on the LifterLMS > Add-ons & more screen

### DIFF
--- a/includes/class-llms-helper-admin-add-ons.php
+++ b/includes/class-llms-helper-admin-add-ons.php
@@ -336,7 +336,7 @@ class LLMS_Helper_Admin_Add_Ons {
 			</label>
 			<a href="<?php echo admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $addon->get( 'id' ) . '&section=changelog&TB_iframe=true&width=600&height=800' ); ?>" class="thickbox open-plugin-details-modal tip--bottom-left" data-tip="<?php esc_attr_e( 'View add-on details', 'lifterlms' ); ?>">
 				<i class="fa fa-info-circle" aria-hidden="true"></i>
-			</span>
+			</a>
 			<?php
 		}
 
@@ -367,11 +367,11 @@ class LLMS_Helper_Admin_Add_Ons {
 				<input class="llms-bulk-check" data-action="update" name="llms_update[]" id="<?php echo esc_attr( sprintf( '%s-update', $addon->get( 'id' ) ) ); ?>" type="checkbox" value="<?php echo esc_attr( $addon->get( 'id' ) ); ?>">
 				<i class="fa fa-check-square-o" aria-hidden="true"></i>
 				<i class="fa fa-arrow-circle-up" aria-hidden="true"></i>
-				<span class="llms-status-text"><?php _e( 'Update', 'lifterlms' ); ?>
+				<span class="llms-status-text"><?php _e( 'Update', 'lifterlms' ); ?></span>
 			</label>
 			<a href="<?php echo admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $addon->get( 'id' ) . '&section=changelog&TB_iframe=true&width=600&height=800' ); ?>" class="thickbox open-plugin-details-modal tip--bottom-left" data-tip="<?php esc_attr_e( 'View update details', 'lifterlms' ); ?>">
 				<i class="fa fa-info-circle" aria-hidden="true"></i>
-			</span>
+			</a>
 			<?php
 		}
 


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description

The Add-ons & more page had some incorrect HTML markup for single Add Ons in the loop. This update fixes those errors.

<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I made the update in my development version of LifterLMS and the changes resolved the display issue. This is the same code update in this helper plugin so its included in core on next build.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

