### PR TITLE
Caching key activations.

### DIFF
--- a/.changelogs/fix_cache-key-activations-1.yml
+++ b/.changelogs/fix_cache-key-activations-1.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: dev
+entry: Added new paramater `$force`, `false` by default, to the static method
+  `LLMS_Helper_Keys::activate_keys()`. It'll allow to force a remote call
+  instead of using ccached results.

--- a/.changelogs/fix_cache-key-activations.yml
+++ b/.changelogs/fix_cache-key-activations.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: performance
+entry: Cache results from the activate keys calls to the LifterLMS license
+  API. This prevents issues where sites are pinging the license server too
+  often, specifically if they are "cloned" sites.

--- a/includes/class-llms-helper-admin-add-ons.php
+++ b/includes/class-llms-helper-admin-add-ons.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Helper/Classes
  *
  * @since 3.0.0
- * @version 3.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-llms-helper-admin-add-ons.php
+++ b/includes/class-llms-helper-admin-add-ons.php
@@ -172,12 +172,13 @@ class LLMS_Helper_Admin_Add_Ons {
 	 * @since 3.0.0
 	 * @since 3.2.0 Don't access $_POST directly.
 	 * @since 3.4.0 Use core textdomain.
+	 * @since [version] Passing force parameter to activate_keys() method.
 	 *
 	 * @return void
 	 */
 	private function handle_activations() {
 
-		$res = LLMS_Helper_Keys::activate_keys( llms_filter_input( INPUT_POST, 'llms_add_keys', FILTER_SANITIZE_STRING ) );
+		$res = LLMS_Helper_Keys::activate_keys( llms_filter_input( INPUT_POST, 'llms_add_keys', FILTER_SANITIZE_STRING ), true );
 
 		if ( is_wp_error( $res ) ) {
 			LLMS_Admin_Notices::flash_notice( $res->get_error_message(), 'error' );

--- a/includes/class-llms-helper-keys.php
+++ b/includes/class-llms-helper-keys.php
@@ -25,7 +25,7 @@ class LLMS_Helper_Keys {
 	 * @since 3.4.2 Removed empty key lines.
 	 * @since [version] Caching results. Added `$force` parameter.
 	 *
-	 * @param string|array $keys Array or a white-space separated list of API keys.
+	 * @param string|array $keys  Array or a white-space separated list of API keys.
 	 * @param bool         $force Optional. Whether to force a remote check. Default `false`.
 	 * @return array
 	 */


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

We are going to cache the results from the activate_keys calls to the LifterLMS license API. You can override that by passing a new $force parameter.

~We need to update the LifterLMS core plugin~ We also updated the code in LLMS_Helper_Admin_Add_Ons::handle_actions in the helper plugin to use the $force parameter when specifically submitting the "add new key" form from the Add Ons & More page.

This prevents issues where sites are pinging the license server too often, specifically if they are "cloned" sites.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

By debugging before and after this block of code (https://github.com/gocodebox/lifterlms-helper/blob/fix/cache-key-activations/includes/class-llms-helper-keys.php#L49-L60) you can see when the code is using the cached result or making a call to the LifterLMS endpoint.

In my tests, only 1 call per day is being made to the endpoint during the llms_site_clone_detected hook. This is correct.
In my tests, a new call is made every time I add a new key from the form on the Add Ons & more page. This is correct.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

