### PR TITLE
Fetching translations for add-ons

### DIFF
--- a/.changelogs/feteching-translations.yml
+++ b/.changelogs/feteching-translations.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: added
+entry: Check for translations in add-ons when available.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.3"
+    "php": ">=7.3",
+    "wearerequired/traduttore-registry": "2.x-dev"
   },
   "require-dev": {
     "lifterlms/lifterlms-cs": "dev-trunk",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,78 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d1b1935f7687a9b7ff631db87c8a75b",
-    "packages": [],
+    "content-hash": "96225fb68d394e92858ffd09c9dd0bf9",
+    "packages": [
+        {
+            "name": "wearerequired/traduttore-registry",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wearerequired/traduttore-registry.git",
+                "reference": "dd13b4418e949ac0322c7e3aa3822cd2b41d3bfc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wearerequired/traduttore-registry/zipball/dd13b4418e949ac0322c7e3aa3822cd2b41d3bfc",
+                "reference": "dd13b4418e949ac0322c7e3aa3822cd2b41d3bfc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpunit/phpunit": "^7.5.13",
+                "wearerequired/coding-standards": "^1.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/namespace.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "required",
+                    "email": "support@required.ch",
+                    "homepage": "https://required.com",
+                    "role": "Company"
+                },
+                {
+                    "name": "Dominik Schilling",
+                    "email": "dominik@required.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Pascal Birchler",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Allows loading translation files from a custom GlotPress site running Traduttore",
+            "homepage": "https://github.com/wearerequired/traduttore-registry",
+            "keywords": [
+                "glotpress",
+                "translations",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/wearerequired/traduttore-registry/issues",
+                "source": "https://github.com/wearerequired/traduttore-registry/tree/master"
+            },
+            "time": "2022-06-10T14:34:24+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "behat/behat",
@@ -5173,6 +5243,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "wearerequired/traduttore-registry": 20,
         "lifterlms/lifterlms-cs": 20
     },
     "prefer-stable": false,

--- a/includes/class-llms-helper-upgrader.php
+++ b/includes/class-llms-helper-upgrader.php
@@ -61,6 +61,8 @@ class LLMS_Helper_Upgrader {
 		add_filter( 'pre_set_site_transient_update_themes', array( $this, 'pre_set_site_transient_update_things' ) );
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'pre_set_site_transient_update_things' ) );
 
+		add_action( 'admin_init', array( $this, 'register_addon_translation_updates' ) );
+
 		$products = llms_get_add_ons();
 		if ( ! is_wp_error( $products ) && isset( $products['items'] ) ) {
 			foreach ( (array) $products['items'] as $product ) {
@@ -68,6 +70,26 @@ class LLMS_Helper_Upgrader {
 				if ( 'plugin' === $product['type'] && $product['update_file'] ) {
 					add_action( "in_plugin_update_message-{$product['update_file']}", array( $this, 'in_plugin_update_message' ), 10, 2 );
 				}
+			}
+		}
+	}
+
+	public function register_addon_translation_updates() {
+		$products = llms_get_add_ons();
+		if ( is_wp_error( $products ) || ! isset( $products['items'] ) ) {
+			return;
+		}
+		foreach ( (array) $products['items'] as $product ) {
+			if ( isset( $product['slug'] ) && $product['slug'] ) {
+				if ( ! is_plugin_active( $product['slug'] . '/' . $product['slug'] . '.php' ) ) {
+					continue;
+				}
+
+				\Required\Traduttore_Registry\add_project(
+					$product['type'],
+					$product['slug'],
+					'https://translate.lifterlms.com/translate/api/translations/' . $product['slug']
+				);
 			}
 		}
 	}

--- a/includes/class-llms-helper-upgrader.php
+++ b/includes/class-llms-helper-upgrader.php
@@ -81,7 +81,9 @@ class LLMS_Helper_Upgrader {
 		}
 		foreach ( (array) $products['items'] as $product ) {
 			if ( isset( $product['slug'] ) && $product['slug'] ) {
-				if ( ! is_plugin_active( $product['slug'] . '/' . $product['slug'] . '.php' ) ) {
+				$addon = llms_get_add_on( $product );
+
+				if ( ! $addon->is_installable() || ! $addon->is_installed() ) {
 					continue;
 				}
 

--- a/includes/class-llms-helper-upgrader.php
+++ b/includes/class-llms-helper-upgrader.php
@@ -74,6 +74,13 @@ class LLMS_Helper_Upgrader {
 		}
 	}
 
+	/**
+	 * Check for translation updates.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
 	public function register_addon_translation_updates() {
 		$products = llms_get_add_ons();
 		if ( is_wp_error( $products ) || ! isset( $products['items'] ) ) {


### PR DESCRIPTION
## Description
Checks and fetches translation language packs from translate.lifterlms.com when available. Only registers active plugins to minimize traffic to the translation server.
Fixes #56 

## How has this been tested?
Manually.

<img width="657" alt="Captura de pantalla 2024-07-11 a las 2 28 42 p  m" src="https://github.com/gocodebox/lifterlms-helper/assets/627497/18957fbc-08e6-4df2-b2f2-755f12bb688e">

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

